### PR TITLE
[feature/166] 카트에서 장소 순서 수정 구현, 경로 리뷰 리스트 조회 response data 추가

### DIFF
--- a/backend/api/src/docs/asciidoc/cart.adoc
+++ b/backend/api/src/docs/asciidoc/cart.adoc
@@ -16,23 +16,29 @@
 `POST /cart/place`
 
 요청 HTTP
-
-- Body
 include::{snippets}/cart-addPlace/http-request.adoc[]
 include::{snippets}/cart-addPlace/request-fields.adoc[]
 
 성공 응답 HTTP
 include::{snippets}/cart-addPlace/http-response.adoc[]
 
+=== 카트에 담겨있는 장소 순서 수정
+
+`PUT /cart/place`
+
+요청 HTTP
+include::{snippets}/cart-update-place-order/http-request.adoc[]
+include::{snippets}/cart-update-place-order/request-fields.adoc[]
+
+성공 응답 HTTP
+include::{snippets}/cart-update-place-order/http-response.adoc[]
+
 === 카트에 담겨있는 장소에 메모 추가
 
 `PUT /cart/place/{placeId}/memo`
 
 요청 HTTP
-
 include::{snippets}/cart-addMemo/path-parameters.adoc[]
-
-- Body
 include::{snippets}/cart-addMemo/http-request.adoc[]
 include::{snippets}/cart-addMemo/request-fields.adoc[]
 
@@ -44,8 +50,6 @@ include::{snippets}/cart-addMemo/http-response.adoc[]
 `GET /cart/my`
 
 요청 HTTP
-
-- Body
 include::{snippets}/cart-getMy/http-request.adoc[]
 
 성공 응답 HTTP
@@ -57,8 +61,6 @@ include::{snippets}/cart-getMy/response-fields.adoc[]
 `DELETE /cart/place/{placeId}`
 
 요청 HTTP
-
-- Body
 include::{snippets}/cart-deleteOnePlace/http-request.adoc[]
 include::{snippets}/cart-deleteOnePlace/path-parameters.adoc[]
 
@@ -70,8 +72,6 @@ include::{snippets}/cart-deleteOnePlace/http-response.adoc[]
 `DELETE /cart/place`
 
 요청 HTTP
-
-- Body
 include::{snippets}/cart-deleteAllPlace/http-request.adoc[]
 
 성공 응답 HTTP

--- a/backend/api/src/main/java/me/travelplan/service/cart/CartPlaceService.java
+++ b/backend/api/src/main/java/me/travelplan/service/cart/CartPlaceService.java
@@ -5,9 +5,9 @@ import me.travelplan.service.cart.domain.CartPlace;
 import me.travelplan.service.cart.exception.CartPlaceNotFoundException;
 import me.travelplan.service.cart.exception.PlaceExistedException;
 import me.travelplan.service.cart.repository.CartPlaceRepository;
+import me.travelplan.service.place.PlaceService;
 import me.travelplan.service.place.domain.Place;
 import me.travelplan.service.place.repository.PlaceRepository;
-import me.travelplan.service.place.PlaceService;
 import me.travelplan.service.user.domain.User;
 import me.travelplan.web.cart.CartPlaceRequest;
 import org.springframework.stereotype.Service;
@@ -31,7 +31,7 @@ public class CartPlaceService {
         if (cartPlaceRepository.findByPlaceIdAndCreatedBy(place.getId(), user).isPresent()) {
             throw new PlaceExistedException();
         }
-        CartPlace cartPlace = CartPlace.create(place);
+        CartPlace cartPlace = CartPlace.create(place, cartPlaceRepository.findMaxOrderByCreatedBy(user));
         cartPlaceRepository.save(cartPlace);
     }
 

--- a/backend/api/src/main/java/me/travelplan/service/cart/CartPlaceService.java
+++ b/backend/api/src/main/java/me/travelplan/service/cart/CartPlaceService.java
@@ -53,6 +53,9 @@ public class CartPlaceService {
 
     public void deleteOnePlace(Long placeId, User user) {
         cartPlaceRepository.deleteByPlaceIdAndCreatedBy(placeId, user);
+
+        List<CartPlace> cartPlace = cartPlaceRepository.findAllByCreatedBy(user);
+        CartPlace.updateAllOrder(cartPlace);
     }
 
     public void deleteAllPlace(User user) {

--- a/backend/api/src/main/java/me/travelplan/service/cart/CartPlaceService.java
+++ b/backend/api/src/main/java/me/travelplan/service/cart/CartPlaceService.java
@@ -45,6 +45,12 @@ public class CartPlaceService {
         cartPlace.addMemo(request.getMemo());
     }
 
+    public void updatePlaceOrder(CartPlaceRequest.UpdateOrder request, User user) {
+        CartPlace firstCartPlace = cartPlaceRepository.findByPlaceIdAndCreatedBy(request.getFirstPlaceId(), user).orElseThrow(CartPlaceNotFoundException::new);
+        CartPlace secondCartPlace = cartPlaceRepository.findByPlaceIdAndCreatedBy(request.getSecondPlaceId(), user).orElseThrow(CartPlaceNotFoundException::new);
+        CartPlace.swapOrder(firstCartPlace, secondCartPlace);
+    }
+
     public void deleteOnePlace(Long placeId, User user) {
         cartPlaceRepository.deleteByPlaceIdAndCreatedBy(placeId, user);
     }

--- a/backend/api/src/main/java/me/travelplan/service/cart/domain/CartPlace.java
+++ b/backend/api/src/main/java/me/travelplan/service/cart/domain/CartPlace.java
@@ -36,4 +36,14 @@ public class CartPlace extends BaseEntity {
                 .order(maxOrder + 1)
                 .build();
     }
+
+    private void updateOrder(Integer order) {
+        this.order = order;
+    }
+
+    public static void swapOrder(CartPlace firstCartPlace, CartPlace secondCartPlace) {
+        Integer tempOrder = firstCartPlace.getOrder();
+        firstCartPlace.updateOrder(secondCartPlace.getOrder());
+        secondCartPlace.updateOrder(tempOrder);
+    }
 }

--- a/backend/api/src/main/java/me/travelplan/service/cart/domain/CartPlace.java
+++ b/backend/api/src/main/java/me/travelplan/service/cart/domain/CartPlace.java
@@ -5,6 +5,7 @@ import me.travelplan.config.jpa.BaseEntity;
 import me.travelplan.service.place.domain.Place;
 
 import javax.persistence.*;
+import java.util.List;
 
 @Getter
 @Builder
@@ -26,6 +27,10 @@ public class CartPlace extends BaseEntity {
     @JoinColumn(name = "place_id")
     private Place place;
 
+    private void updateOrder(Integer order) {
+        this.order = order;
+    }
+
     public void addMemo(String memo) {
         this.memo = memo;
     }
@@ -37,8 +42,11 @@ public class CartPlace extends BaseEntity {
                 .build();
     }
 
-    private void updateOrder(Integer order) {
-        this.order = order;
+    public static void updateAllOrder(List<CartPlace> cartPlaces) {
+        int i = 1;
+        for (CartPlace cartPlace : cartPlaces) {
+            cartPlace.updateOrder(i++);
+        }
     }
 
     public static void swapOrder(CartPlace firstCartPlace, CartPlace secondCartPlace) {

--- a/backend/api/src/main/java/me/travelplan/service/cart/domain/CartPlace.java
+++ b/backend/api/src/main/java/me/travelplan/service/cart/domain/CartPlace.java
@@ -19,6 +19,9 @@ public class CartPlace extends BaseEntity {
 
     private String memo;
 
+    @Column(name = "`order`")
+    private Integer order;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "place_id")
     private Place place;
@@ -27,9 +30,10 @@ public class CartPlace extends BaseEntity {
         this.memo = memo;
     }
 
-    public static CartPlace create(Place place) {
+    public static CartPlace create(Place place, Integer maxOrder) {
         return CartPlace.builder()
                 .place(place)
+                .order(maxOrder + 1)
                 .build();
     }
 }

--- a/backend/api/src/main/java/me/travelplan/service/cart/repository/CartPlaceRepository.java
+++ b/backend/api/src/main/java/me/travelplan/service/cart/repository/CartPlaceRepository.java
@@ -3,22 +3,13 @@ package me.travelplan.service.cart.repository;
 import me.travelplan.service.cart.domain.CartPlace;
 import me.travelplan.service.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface CartPlaceRepository extends JpaRepository<CartPlace, Long>, CartPlaceRepositoryCustom {
     Optional<CartPlace> findByPlaceIdAndCreatedBy(Long placeId, User user);
 
-    @Query("select c from CartPlace c join fetch c.place p join fetch p.category where c.createdBy=:user")
-    List<CartPlace> findAllByCreatedBy(@Param("user") User user);
-
     void deleteByPlaceIdAndCreatedBy(Long placeId, User user);
 
-    @Modifying
-    @Query("delete from CartPlace c where c.createdBy=:user")
-    void deleteAllByCreatedBy(@Param("user") User user);
+    void deleteAllByCreatedBy(User user);
 }

--- a/backend/api/src/main/java/me/travelplan/service/cart/repository/CartPlaceRepository.java
+++ b/backend/api/src/main/java/me/travelplan/service/cart/repository/CartPlaceRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 import java.util.Optional;
 
-public interface CartPlaceRepository extends JpaRepository<CartPlace, Long> {
+public interface CartPlaceRepository extends JpaRepository<CartPlace, Long>, CartPlaceRepositoryCustom {
     Optional<CartPlace> findByPlaceIdAndCreatedBy(Long placeId, User user);
 
     @Query("select c from CartPlace c join fetch c.place p join fetch p.category where c.createdBy=:user")

--- a/backend/api/src/main/java/me/travelplan/service/cart/repository/CartPlaceRepositoryCustom.java
+++ b/backend/api/src/main/java/me/travelplan/service/cart/repository/CartPlaceRepositoryCustom.java
@@ -1,0 +1,7 @@
+package me.travelplan.service.cart.repository;
+
+import me.travelplan.service.user.domain.User;
+
+public interface CartPlaceRepositoryCustom {
+    Integer findMaxOrderByCreatedBy(User user);
+}

--- a/backend/api/src/main/java/me/travelplan/service/cart/repository/CartPlaceRepositoryCustom.java
+++ b/backend/api/src/main/java/me/travelplan/service/cart/repository/CartPlaceRepositoryCustom.java
@@ -1,7 +1,12 @@
 package me.travelplan.service.cart.repository;
 
+import me.travelplan.service.cart.domain.CartPlace;
 import me.travelplan.service.user.domain.User;
+
+import java.util.List;
 
 public interface CartPlaceRepositoryCustom {
     Integer findMaxOrderByCreatedBy(User user);
+
+    List<CartPlace> findAllByCreatedBy(User user);
 }

--- a/backend/api/src/main/java/me/travelplan/service/cart/repository/CartPlaceRepositoryImpl.java
+++ b/backend/api/src/main/java/me/travelplan/service/cart/repository/CartPlaceRepositoryImpl.java
@@ -1,0 +1,24 @@
+package me.travelplan.service.cart.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import me.travelplan.service.user.domain.User;
+
+import static me.travelplan.service.cart.domain.QCartPlace.cartPlace;
+
+@RequiredArgsConstructor
+public class CartPlaceRepositoryImpl implements CartPlaceRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Integer findMaxOrderByCreatedBy(User user) {
+        Integer maxOrder = queryFactory.select(cartPlace.order.max())
+                .from(cartPlace)
+                .where(cartPlace.createdBy.eq(user))
+                .fetchOne();
+        if (maxOrder == null) {
+            return 0;
+        }
+        return maxOrder;
+    }
+}

--- a/backend/api/src/main/java/me/travelplan/service/cart/repository/CartPlaceRepositoryImpl.java
+++ b/backend/api/src/main/java/me/travelplan/service/cart/repository/CartPlaceRepositoryImpl.java
@@ -2,9 +2,13 @@ package me.travelplan.service.cart.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import me.travelplan.service.cart.domain.CartPlace;
 import me.travelplan.service.user.domain.User;
 
+import java.util.List;
+
 import static me.travelplan.service.cart.domain.QCartPlace.cartPlace;
+import static me.travelplan.service.place.domain.QPlace.place;
 
 @RequiredArgsConstructor
 public class CartPlaceRepositoryImpl implements CartPlaceRepositoryCustom {
@@ -20,5 +24,17 @@ public class CartPlaceRepositoryImpl implements CartPlaceRepositoryCustom {
             return 0;
         }
         return maxOrder;
+    }
+
+    @Override
+    public List<CartPlace> findAllByCreatedBy(User user) {
+        return queryFactory.selectFrom(cartPlace)
+                .join(cartPlace.place, place).fetchJoin()
+                .join(place.category).fetchJoin()
+                .where(cartPlace.createdBy.eq(user))
+                .orderBy(cartPlace.order.asc())
+                .fetch();
+
+
     }
 }

--- a/backend/api/src/main/java/me/travelplan/service/cart/repository/CartPlaceRepositoryImpl.java
+++ b/backend/api/src/main/java/me/travelplan/service/cart/repository/CartPlaceRepositoryImpl.java
@@ -34,7 +34,5 @@ public class CartPlaceRepositoryImpl implements CartPlaceRepositoryCustom {
                 .where(cartPlace.createdBy.eq(user))
                 .orderBy(cartPlace.order.asc())
                 .fetch();
-
-
     }
 }

--- a/backend/api/src/main/java/me/travelplan/web/cart/CartController.java
+++ b/backend/api/src/main/java/me/travelplan/web/cart/CartController.java
@@ -23,6 +23,11 @@ public class CartController {
         return cartMapper.toGetListResponse(cartPlaceService.getMyCart(customUserDetails.getUser()), customUserDetails.getUser());
     }
 
+    @PutMapping("/place")
+    public void updatePlaceOrder(@RequestBody CartPlaceRequest.UpdateOrder request, @CurrentUser CustomUserDetails customUserDetails) {
+        cartPlaceService.updatePlaceOrder(request, customUserDetails.getUser());
+    }
+
     @PutMapping("/place/{placeId}/memo")
     public void addMemo(@PathVariable Long placeId, @RequestBody CartPlaceRequest.AddMemo request, @CurrentUser CustomUserDetails customUserDetails) {
         cartPlaceService.addMemo(placeId, request, customUserDetails.getUser());

--- a/backend/api/src/main/java/me/travelplan/web/cart/CartPlaceDto.java
+++ b/backend/api/src/main/java/me/travelplan/web/cart/CartPlaceDto.java
@@ -15,6 +15,7 @@ public class CartPlaceDto {
         private String address;
         private String memo;
         private String url;
+        private Integer order;
         private boolean likeCheck;
     }
 }

--- a/backend/api/src/main/java/me/travelplan/web/cart/CartPlaceMapper.java
+++ b/backend/api/src/main/java/me/travelplan/web/cart/CartPlaceMapper.java
@@ -31,6 +31,7 @@ public interface CartPlaceMapper {
                     .categoryId(cartPlace.getPlace().getCategory().getId())
                     .categoryName(cartPlace.getPlace().getCategory().getName())
                     .memo(cartPlace.getMemo())
+                    .order(cartPlace.getOrder())
                     .likeCheck(cartPlace.getPlace().isLike(user))
                     .url(cartPlace.getPlace().getUrl())
                     .build();

--- a/backend/api/src/main/java/me/travelplan/web/cart/CartPlaceRequest.java
+++ b/backend/api/src/main/java/me/travelplan/web/cart/CartPlaceRequest.java
@@ -28,4 +28,13 @@ public class CartPlaceRequest {
     public static class AddMemo {
         private String memo;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UpdateOrder {
+        private Long firstPlaceId;
+        private Long secondPlaceId;
+    }
 }

--- a/backend/api/src/main/java/me/travelplan/web/route/RouteDto.java
+++ b/backend/api/src/main/java/me/travelplan/web/route/RouteDto.java
@@ -49,7 +49,7 @@ public class RouteDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
-    public static class RouteCreator {
+    public static class Creator {
         private String name;
         private String avatar;
     }
@@ -82,7 +82,7 @@ public class RouteDto {
         private Long id;
         private String content;
         private Double score;
-        private String createdBy;
+        private RouteDto.Creator creator;
         private Integer likeCount;
         private boolean likeCheck;
         private List<FileDto> files;

--- a/backend/api/src/main/java/me/travelplan/web/route/RouteMapper.java
+++ b/backend/api/src/main/java/me/travelplan/web/route/RouteMapper.java
@@ -74,7 +74,7 @@ public interface RouteMapper {
         Double centerX = map.get("centerX");
         Double centerY = map.get("centerY");
 
-        RouteDto.RouteCreator.RouteCreatorBuilder creatorBuilder = RouteDto.RouteCreator.builder()
+        RouteDto.Creator.CreatorBuilder creatorBuilder = RouteDto.Creator.builder()
                 .name(route.getCreatedBy().getName());
         if (route.getCreatedBy().getAvatar() != null) {
             creatorBuilder.avatar(route.getCreatedBy().getAvatar().getUrl());
@@ -149,21 +149,28 @@ public interface RouteMapper {
 
     default RouteResponse.ReviewList entityToResponseReviewList(List<RouteReview> reviews, CustomUserDetails customUserDetails) {
         return RouteResponse.ReviewList.builder()
-                .reviews(reviews.stream().map(routeReview -> RouteDto.ReviewResponse.builder()
-                        .id(routeReview.getId())
-                        .content(routeReview.getContent())
-                        .score(routeReview.getScore())
-                        .likeCheck(routeReview.isLike(customUserDetails))
-                        .likeCount(routeReview.getRouteReviewLikes().size())
-                        .createdBy(routeReview.getCreatedBy().getName())
-                        .files(routeReview.getRouteReviewFiles().stream()
-                                .map(routeReviewFile -> FileDto.builder()
-                                        .url(routeReviewFile.getFile().getUrl())
-                                        .build())
-                                .collect(Collectors.toList()))
-                        .createdAt(routeReview.getCreatedAt())
-                        .updatedAt(routeReview.getUpdatedAt())
-                        .build()).collect(Collectors.toList()))
+                .reviews(reviews.stream().map(routeReview -> {
+                    RouteDto.Creator.CreatorBuilder creatorBuilder = RouteDto.Creator.builder()
+                            .name(routeReview.getCreatedBy().getName());
+                    if (routeReview.getCreatedBy().getAvatar() != null) {
+                        creatorBuilder.avatar(routeReview.getCreatedBy().getAvatar().getUrl());
+                    }
+                    return RouteDto.ReviewResponse.builder()
+                            .id(routeReview.getId())
+                            .content(routeReview.getContent())
+                            .score(routeReview.getScore())
+                            .likeCheck(routeReview.isLike(customUserDetails))
+                            .likeCount(routeReview.getRouteReviewLikes().size())
+                            .creator(creatorBuilder.build())
+                            .files(routeReview.getRouteReviewFiles().stream()
+                                    .map(routeReviewFile -> FileDto.builder()
+                                            .url(routeReviewFile.getFile().getUrl())
+                                            .build())
+                                    .collect(Collectors.toList()))
+                            .createdAt(routeReview.getCreatedAt())
+                            .updatedAt(routeReview.getUpdatedAt())
+                            .build();
+                }).collect(Collectors.toList()))
                 .build();
     }
 

--- a/backend/api/src/main/java/me/travelplan/web/route/RouteResponse.java
+++ b/backend/api/src/main/java/me/travelplan/web/route/RouteResponse.java
@@ -28,7 +28,7 @@ public class RouteResponse {
         public LocalDateTime createdAt;
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
         public LocalDateTime updatedAt;
-        private RouteDto.RouteCreator creator;
+        private RouteDto.Creator creator;
         private List<RouteDto.RoutePlace> places;
     }
 

--- a/backend/api/src/main/resources/db/migration/V20210423102656__Create_Carts_Places_Table.sql
+++ b/backend/api/src/main/resources/db/migration/V20210423102656__Create_Carts_Places_Table.sql
@@ -2,8 +2,9 @@ DROP TABLE IF EXISTS `carts_places`;
 CREATE TABLE `carts_places`
 (
     `id`         BIGINT   NOT NULL AUTO_INCREMENT,
-    `place_id`   BIGINT   NOT NULL,
+    `order`      INT      NOT NULL,
     `memo`       VARCHAR(1000),
+    `place_id`   BIGINT   NOT NULL,
     `created_at` DATETIME NOT NULL,
     `updated_at` DATETIME DEFAULT NULL,
     `deleted_at` DATETIME DEFAULT NULL,

--- a/backend/api/src/rest/CartController.http
+++ b/backend/api/src/rest/CartController.http
@@ -38,6 +38,17 @@ Authorization: {{authorizationToken}}
 
 ###
 
+PUT {{apiUrl}}/cart/place
+Content-Type: application/json;charset=UTF-8
+Authorization: {{authorizationToken}}
+
+{
+  "firstPlaceId": 1797997961,
+  "secondPlaceId": 1440347564
+}
+
+###
+
 PUT {{apiUrl}}/cart/place/1797997961/memo
 Content-Type: application/json;charset=UTF-8
 Authorization: {{authorizationToken}}

--- a/backend/api/src/rest/CartController.http
+++ b/backend/api/src/rest/CartController.http
@@ -29,6 +29,22 @@ Authorization: {{authorizationToken}}
   "categoryId": "CE7",
   "categoryName": "카페"
 }
+###
+
+POST {{apiUrl}}/cart/place
+Content-Type: application/json;charset=UTF-8
+Authorization: {{authorizationToken}}
+
+{
+  "id": 8174854,
+  "name": "오장동흥남집 본점",
+  "url": "https://place.map.kakao.com/8174854",
+  "x": 37.554619995803215,
+  "y": 126.91083170563417,
+  "address": "서울 중구 마른내로 114 (우)04559",
+  "categoryId": "CE7",
+  "categoryName": "카페"
+}
 
 ###
 

--- a/backend/api/src/rest/RouteController.http
+++ b/backend/api/src/rest/RouteController.http
@@ -73,12 +73,12 @@ Content-Type: multipart/form-data; boundary=WebAppBoundary
 --WebAppBoundary
 Content-Disposition: form-data; name="files"; filename="enjoy.png"
 
-< C:\Users\Administrator\Desktop\baruntravel\baruntravel\backend\api\src\main\resources\mock\images\enjoy.png
+< ./../main/resources/mock/images/enjoy.png
 
 --WebAppBoundary
 Content-Disposition: form-data; name="files"; filename="enjoy2.png"
 
-< C:\Users\Administrator\Desktop\baruntravel\baruntravel\backend\api\src\main\resources\mock\images\enjoy2.png
+< ./../main/resources/mock/images/enjoy2.png
 
 --WebAppBoundary
 Content-Disposition: form-data; name="content"
@@ -120,7 +120,7 @@ Content-Type: multipart/form-data; boundary=WebAppBoundary
 --WebAppBoundary
 Content-Disposition: form-data; name="files"; filename="enjoy2.png"
 
-< C:\Users\Administrator\Desktop\baruntravel\baruntravel\backend\api\src\main\resources\mock\images\enjoy2.png
+< ./../main/resources/mock/images/enjoy2.png
 
 --WebAppBoundary
 Content-Disposition: form-data; name="content"

--- a/backend/api/src/test/java/me/travelplan/web/CartControllerTest.java
+++ b/backend/api/src/test/java/me/travelplan/web/CartControllerTest.java
@@ -98,6 +98,7 @@ public class CartControllerTest extends MvcTest {
                         .thumbnail(File.builder().url("http://loremflickr.com/440/440").build())
                         .build())
                 .memo("첫번째 테스트 메모입니다~!")
+                .order(1)
                 .build();
         cartPlaceList.add(cartPlace1);
         CartPlace cartPlace2 = CartPlace.builder()
@@ -112,6 +113,7 @@ public class CartControllerTest extends MvcTest {
                         .thumbnail(File.builder().url("http://loremflickr.com/440/440").build())
                         .build())
                 .memo("두번째 테스트 메모입니다~!")
+                .order(2)
                 .build();
         cartPlaceList.add(cartPlace2);
         CartPlace cartPlace3 = CartPlace.builder()
@@ -126,6 +128,7 @@ public class CartControllerTest extends MvcTest {
                         .thumbnail(File.builder().url("http://loremflickr.com/440/440").build())
                         .build())
                 .memo("세번째 테스트 메모입니다~!")
+                .order(3)
                 .build();
         cartPlaceList.add(cartPlace3);
 
@@ -149,6 +152,7 @@ public class CartControllerTest extends MvcTest {
                                 fieldWithPath("places[].memo").description("장소에 대한 메모 (메모가 없다면 null)"),
                                 fieldWithPath("places[].likeCheck").description("장소 좋아요"),
                                 fieldWithPath("places[].url").description("장소 URL"),
+                                fieldWithPath("places[].order").description("카트에 담긴 장소 순서"),
                                 fieldWithPath("places[].categoryId").description("장소 카테고리 식별자"),
                                 fieldWithPath("places[].categoryName").description("장소 카테고리 이름")
                         )

--- a/backend/api/src/test/java/me/travelplan/web/CartControllerTest.java
+++ b/backend/api/src/test/java/me/travelplan/web/CartControllerTest.java
@@ -2,8 +2,8 @@ package me.travelplan.web;
 
 import me.travelplan.MvcTest;
 import me.travelplan.WithMockCustomUser;
-import me.travelplan.service.cart.domain.CartPlace;
 import me.travelplan.service.cart.CartPlaceService;
+import me.travelplan.service.cart.domain.CartPlace;
 import me.travelplan.service.file.domain.File;
 import me.travelplan.service.place.domain.Place;
 import me.travelplan.service.place.domain.PlaceCategory;
@@ -157,6 +157,33 @@ public class CartControllerTest extends MvcTest {
 
     @Test
     @WithMockCustomUser
+    @DisplayName("카트에 담겨있는 장소 순서 수정")
+    public void updateOrder() throws Exception {
+        CartPlaceRequest.UpdateOrder request = CartPlaceRequest.UpdateOrder.builder()
+                .firstPlaceId(123L)
+                .secondPlaceId(124L)
+                .build();
+
+        ResultActions results = mockMvc.perform(
+                put("/cart/place")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("UTF-8")
+        );
+
+        results.andExpect(status().isOk())
+                .andDo(document("cart-update-place-order",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        requestFields(
+                                fieldWithPath("firstPlaceId").type(JsonFieldType.NUMBER).description("장소 식별자"),
+                                fieldWithPath("secondPlaceId").type(JsonFieldType.NUMBER).description("장소 식별자")
+                        )
+                ));
+    }
+
+    @Test
+    @WithMockCustomUser
     @DisplayName("카트에 담겨있는 장소에 메모 추가")
     public void addMemo() throws Exception {
         CartPlaceRequest.AddMemo request = CartPlaceRequest.AddMemo.builder()
@@ -164,7 +191,7 @@ public class CartControllerTest extends MvcTest {
                 .build();
 
         ResultActions results = mockMvc.perform(
-                put("/cart/place/{placeId}/memo",123L)
+                put("/cart/place/{placeId}/memo", 123L)
                         .content(objectMapper.writeValueAsString(request))
                         .contentType(MediaType.APPLICATION_JSON)
                         .characterEncoding("UTF-8")

--- a/backend/api/src/test/java/me/travelplan/web/RouteControllerTest.java
+++ b/backend/api/src/test/java/me/travelplan/web/RouteControllerTest.java
@@ -309,7 +309,7 @@ public class RouteControllerTest extends MvcTest {
                     .build();
             routeReview.setCreatedAt(LocalDateTime.of(2021, 4, 14, 9, 0));
             routeReview.setUpdatedAt(LocalDateTime.of(2021, 4, 14, 9, 0).plusDays(5));
-            routeReview.setCreatedBy(User.builder().name("테스트유저").build());
+            routeReview.setCreatedBy(User.builder().name("테스트유저").avatar(File.builder().url("https://s3.ap-northeast-2.amazonaws.com/s3.baruntravel.me/NVKd7InpFVTtespa79wvLKMj7MyGdovTroWJI7nInwpF4symIR4J3VQLpTxn.png").build()).build());
             return routeReview;
         }).collect(Collectors.toList());
 
@@ -329,15 +329,16 @@ public class RouteControllerTest extends MvcTest {
                                 parameterWithName("id").description("경로 식별자")
                         ),
                         responseFields(
-                                fieldWithPath("reviews[].id").description("경로 리뷰 식별자"),
-                                fieldWithPath("reviews[].content").description("경로 리뷰 내용"),
-                                fieldWithPath("reviews[].score").description("경로 리뷰 점수"),
-                                fieldWithPath("reviews[].likeCount").description("경로 리뷰 좋아요 개수"),
-                                fieldWithPath("reviews[].likeCheck").description("로그인 유저가 해당 경로 리뷰에 좋아요를 눌렀다면 true"),
-                                fieldWithPath("reviews[].createdBy").description("경로 리뷰 작성자"),
-                                fieldWithPath("reviews[].files[].url").description("경로 리뷰에 첨부되어 있는 파일 url"),
-                                fieldWithPath("reviews[].createdAt").description("경로 리뷰 생성날짜"),
-                                fieldWithPath("reviews[].updatedAt").description("경로 리뷰 수정날짜")
+                                fieldWithPath("reviews[].id").type(JsonFieldType.NUMBER).description("경로 리뷰 식별자"),
+                                fieldWithPath("reviews[].content").type(JsonFieldType.STRING).description("경로 리뷰 내용"),
+                                fieldWithPath("reviews[].score").type(JsonFieldType.NUMBER).description("경로 리뷰 점수"),
+                                fieldWithPath("reviews[].likeCount").type(JsonFieldType.NUMBER).description("경로 리뷰 좋아요 개수"),
+                                fieldWithPath("reviews[].likeCheck").type(JsonFieldType.BOOLEAN).description("로그인 유저가 해당 경로 리뷰에 좋아요를 눌렀다면 true"),
+                                fieldWithPath("reviews[].creator.name").type(JsonFieldType.STRING).description("경로 리뷰 작성자 이름"),
+                                fieldWithPath("reviews[].creator.avatar").type(JsonFieldType.STRING).description("경로 리뷰 작성자 프로필 이미지"),
+                                fieldWithPath("reviews[].files[].url").type(JsonFieldType.STRING).description("경로 리뷰에 첨부되어 있는 파일 url"),
+                                fieldWithPath("reviews[].createdAt").type(JsonFieldType.STRING).description("경로 리뷰 생성날짜"),
+                                fieldWithPath("reviews[].updatedAt").type(JsonFieldType.STRING).description("경로 리뷰 수정날짜")
                         )
                 ));
     }


### PR DESCRIPTION
RouteController에 경로 순서 바꾸는 기능을 추가했었는데 CartController에서 카트에서 경로 순서 수정하는 것이 맞는 것 같아서 수정해놨습니다. 수정하는 과정에서 클라이언트에서 카트에 담긴 장소 리스트을 조회해 올 때 순서가 필요한 것 같아서 CartPlace에 order를 추가해서 진행했습니다