### PR TITLE
[feature/233] 루트 짜기 페이지 기능 추가

### DIFF
--- a/frontend/src/api/cartAPI.js
+++ b/frontend/src/api/cartAPI.js
@@ -79,7 +79,7 @@ export const onEditOrder = (firstPlaceId, secondPlaceId) => {
     firstPlaceId,
     secondPlaceId,
   };
-  axios
+  return axios
     .put(`/cart/place`, data)
     .then((res) => true)
     .catch((error) => {

--- a/frontend/src/api/cartAPI.js
+++ b/frontend/src/api/cartAPI.js
@@ -34,7 +34,7 @@ export const onReceiveCart = async () => {
     });
 };
 
-export const onDeleteCartItem = (placeId) => {
+export const onDeleteCart = (placeId) => {
   return axios
     .delete(`/cart/place/${placeId}`)
     .then((res) => {

--- a/frontend/src/api/cartAPI.js
+++ b/frontend/src/api/cartAPI.js
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-export const onAddCart = async (place) => {
+export const onAddCart = (place) => {
   const data = {
     id: Number(place.id),
     name: place.place_name,
@@ -11,7 +11,7 @@ export const onAddCart = async (place) => {
     categoryId: place.category_group_code,
     categoryName: place.category_group_name,
   };
-  await axios
+  return axios
     .post("/cart/place", data)
     .then((res) => {
       return true;
@@ -34,8 +34,8 @@ export const onReceiveCart = async () => {
     });
 };
 
-export const onDeleteCartItem = async (placeId) => {
-  await axios
+export const onDeleteCartItem = (placeId) => {
+  return axios
     .delete(`/cart/place/${placeId}`)
     .then((res) => {
       return true;

--- a/frontend/src/components/common/cartIcon/cartIcon.jsx
+++ b/frontend/src/components/common/cartIcon/cartIcon.jsx
@@ -3,7 +3,7 @@ import styles from "./cartIcon.module.css";
 import { ShoppingCartOutlined } from "@ant-design/icons";
 import { Drawer } from "antd";
 import ShoppingCart from "../shoppingCart/shoppingCart";
-import { onDeleteCartAll, onDeleteCartItem } from "../../../api/cartAPI";
+import { onDeleteCart, onDeleteCartAll } from "../../../api/cartAPI";
 
 const CartIcon = ({ userStates, items, onUpdateItems }) => {
   const [cartVisible, setCartVisible] = useState(false);
@@ -22,7 +22,7 @@ const CartIcon = ({ userStates, items, onUpdateItems }) => {
 
   const onDeleteItem = useCallback(
     async (id) => {
-      await onDeleteCartItem(id);
+      await onDeleteCart(id);
       onUpdateItems();
     },
     [onUpdateItems]

--- a/frontend/src/components/common/cartIcon/cartIcon.jsx
+++ b/frontend/src/components/common/cartIcon/cartIcon.jsx
@@ -21,9 +21,9 @@ const CartIcon = ({ userStates, items, onUpdateItems }) => {
   }, []);
 
   const onDeleteItem = useCallback(
-    (id) => {
+    async (id) => {
+      await onDeleteCartItem(id);
       onUpdateItems();
-      onDeleteCartItem(id);
     },
     [onUpdateItems]
   );
@@ -32,17 +32,14 @@ const CartIcon = ({ userStates, items, onUpdateItems }) => {
     setDeleteItemId(id);
   }, []);
 
-  const resetCartAll = useCallback(() => {
+  const resetCartAll = useCallback(async () => {
+    await onDeleteCartAll();
     onUpdateItems();
-    onDeleteCartAll();
   }, [onUpdateItems]);
 
   return (
     <div className={styles.CartIcon}>
-      <ShoppingCartOutlined
-        className={styles.icon}
-        onClick={setCartVisibleTrue}
-      />
+      <ShoppingCartOutlined className={styles.icon} onClick={setCartVisibleTrue} />
       <Drawer
         placement="right"
         closable={false}

--- a/frontend/src/components/common/cartIcon/cartIcon.jsx
+++ b/frontend/src/components/common/cartIcon/cartIcon.jsx
@@ -1,0 +1,73 @@
+import React, { useCallback, useState } from "react";
+import styles from "./cartIcon.module.css";
+import { ShoppingCartOutlined } from "@ant-design/icons";
+import { Drawer } from "antd";
+import ShoppingCart from "../shoppingCart/shoppingCart";
+import { onDeleteCartAll, onDeleteCartItem } from "../../../api/cartAPI";
+
+const CartIcon = ({ userStates, items, onUpdateItems }) => {
+  const [cartVisible, setCartVisible] = useState(false);
+  const [deleteItemId, setDeleteItemId] = useState(null);
+
+  const setCartVisibleTrue = useCallback(() => {
+    // if (userStates.isLogin) {
+    setCartVisible(true);
+    // } else {
+    // setNeedLogin(true);
+    // }
+  }, [userStates]);
+  const setCartVisibleFalse = useCallback(() => {
+    setCartVisible(false);
+  }, []);
+
+  const onDeleteItem = useCallback(
+    (id) => {
+      onUpdateItems();
+      onDeleteCartItem(id);
+    },
+    [onUpdateItems]
+  );
+
+  const onSetItemForDelete = useCallback((id) => {
+    setDeleteItemId(id);
+  }, []);
+
+  const resetCartAll = useCallback(() => {
+    onUpdateItems();
+    onDeleteCartAll();
+  }, [onUpdateItems]);
+
+  return (
+    <div className={styles.CartIcon}>
+      <ShoppingCartOutlined
+        className={styles.icon}
+        onClick={setCartVisibleTrue}
+      />
+      <Drawer
+        placement="right"
+        closable={false}
+        visible={cartVisible}
+        onClose={setCartVisibleFalse}
+        width={window.innerWidth > 768 ? "36vw" : "80vw"}
+        bodyStyle={{
+          backgroundColor: "#ebecec",
+          padding: 0,
+        }}
+        zIndex={1004}
+      >
+        <ShoppingCart
+          items={items}
+          deleteClickedItemId={onSetItemForDelete}
+          updateShoppingCart={onUpdateItems}
+          // updateMemoShoppingItem={updateMemoShoppingItem}
+          resetCartAll={resetCartAll}
+          onClose={setCartVisibleFalse}
+          deleteItemId={deleteItemId}
+          onDeleteItem={onDeleteItem}
+        />
+      </Drawer>
+    </div>
+  );
+};
+
+export default CartIcon;

--- a/frontend/src/components/common/shoppingCart/shoppingCart.jsx
+++ b/frontend/src/components/common/shoppingCart/shoppingCart.jsx
@@ -52,10 +52,7 @@ const ShoppingCart = memo(
         if (!destination || reason === "CANCEL") {
           return;
         }
-        if (
-          destination.droppableId === source.droppableId &&
-          destination.index === source.index
-        ) {
+        if (destination.droppableId === source.droppableId && destination.index === source.index) {
           return;
         }
         const updateItems = [...items];
@@ -85,10 +82,7 @@ const ShoppingCart = memo(
             <header className={styles.shoppingCartHeader}>
               <span className={styles.title}>나의 담은 목록</span>
               <div className={styles.header__btnBox}>
-                <button
-                  className={styles.resetBtn}
-                  onClick={onOpenResetConfirm}
-                >
+                <button className={styles.resetBtn} onClick={onOpenResetConfirm}>
                   <HistoryOutlined />
                 </button>
                 <button className={styles.closeBtn} onClick={onClose}>
@@ -98,18 +92,10 @@ const ShoppingCart = memo(
             </header>
             <Droppable droppableId="list">
               {(provided) => (
-                <ul
-                  className={styles.list}
-                  ref={provided.innerRef}
-                  {...provided.droppableProps}
-                >
+                <ul className={styles.list} ref={provided.innerRef} {...provided.droppableProps}>
                   {items &&
                     items.map((item, index) => (
-                      <Draggable
-                        key={item.id}
-                        draggableId={`${item.id}`}
-                        index={index}
-                      >
+                      <Draggable key={item.id} draggableId={`${item.id}`} index={index}>
                         {(provided) => (
                           <div
                             key={index}
@@ -142,18 +128,10 @@ const ShoppingCart = memo(
             </div>
           </div>
         </DragDropContext>
-        {openInputName && (
-          <InputRootName onClose={onCloseInputName} onSaveRoute={onSaveRoute} />
-        )}
-        {openResetConfirm && (
-          <ResetConfirm onReset={resetCartAll} onClose={onCloseResetConfirm} />
-        )}
+        {openInputName && <InputRootName onClose={onCloseInputName} onSaveRoute={onSaveRoute} />}
+        {openResetConfirm && <ResetConfirm onReset={resetCartAll} onClose={onCloseResetConfirm} />}
         {deleteConfirm && (
-          <DeleteConfirm
-            deleteItemId={deleteItemId}
-            onDeleteItem={onDeleteItem}
-            onClose={onCloseDeleteConfirm}
-          />
+          <DeleteConfirm deleteItemId={deleteItemId} onDeleteItem={onDeleteItem} onClose={onCloseDeleteConfirm} />
         )}
       </>
     );

--- a/frontend/src/components/common/shoppingCart/shoppingCart.jsx
+++ b/frontend/src/components/common/shoppingCart/shoppingCart.jsx
@@ -47,7 +47,7 @@ const ShoppingCart = memo(
       setDeleteConfirm(false);
     }, []);
     const onDragEnd = useCallback(
-      (result) => {
+      async (result) => {
         const { destination, source, reason } = result;
         if (!destination || reason === "CANCEL") {
           return;
@@ -57,8 +57,7 @@ const ShoppingCart = memo(
         }
         const updateItems = [...items];
         const droppedItem = items[source.index];
-        onEditOrder(droppedItem.id, updateItems[destination.index].id);
-        // onEditOrder(updateItems[destination.index].id, droppedItem.id);
+        await onEditOrder(droppedItem.id, updateItems[destination.index].id);
 
         updateItems.splice(source.index, 1);
         updateItems.splice(destination.index, 0, droppedItem);

--- a/frontend/src/components/routeDetailPage/imageMap/imageMap.jsx
+++ b/frontend/src/components/routeDetailPage/imageMap/imageMap.jsx
@@ -11,7 +11,10 @@ const ImageMap = ({ places, centerX, centerY }) => {
       // 초기 지도 생성 시 어느 지역의 지도를 보여줄 것인가?
       let staticMapContainer = document.getElementById("staticMap"),
         staticMapOption = {
-          center: new kakao.maps.LatLng(centerY || 37.566826, centerX || 126.9786567),
+          center: new kakao.maps.LatLng(
+            centerY || 37.566826,
+            centerX || 126.9786567
+          ),
           level: 4,
         };
       let map = new kakao.maps.Map(staticMapContainer, staticMapOption);
@@ -26,14 +29,19 @@ const ImageMap = ({ places, centerX, centerY }) => {
       staticMap.setCenter(new kakao.maps.LatLng(centerY, centerX));
     }
     function addMarker(position, index, map) {
-      var imageSrc = "https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/marker_number_blue.png", // 마커 이미지 url, 스프라이트 이미지를 씁니다
+      var imageSrc =
+          "https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/marker_number_blue.png", // 마커 이미지 url, 스프라이트 이미지를 씁니다
         imageSize = new kakao.maps.Size(36, 37), // 마커 이미지의 크기
         imgOptions = {
           spriteSize: new kakao.maps.Size(36, 691), // 스프라이트 이미지의 크기
           spriteOrigin: new kakao.maps.Point(0, index * 46 + 10), // 스프라이트 이미지 중 사용할 영역의 좌상단 좌표
           offset: new kakao.maps.Point(13, 37), // 마커 좌표에 일치시킬 이미지 내에서의 좌표
         },
-        markerImage = new kakao.maps.MarkerImage(imageSrc, imageSize, imgOptions),
+        markerImage = new kakao.maps.MarkerImage(
+          imageSrc,
+          imageSize,
+          imgOptions
+        ),
         marker = new kakao.maps.Marker({
           position: position, // 마커의 위치
           image: markerImage,
@@ -41,7 +49,6 @@ const ImageMap = ({ places, centerX, centerY }) => {
 
       marker.setMap(map); // 지도 위에 마커를 표출합니다
       setMarkers((markers) => [...markers, marker]);
-
       return marker;
     }
     function displayMarker(map) {
@@ -49,7 +56,7 @@ const ImageMap = ({ places, centerX, centerY }) => {
       let bounds = new kakao.maps.LatLngBounds();
       for (let i = 0; i < places.length; i++) {
         let placePosition = new kakao.maps.LatLng(places[i].y, places[i].x);
-        let marker = addMarker(placePosition, i, map);
+        addMarker(placePosition, i, map);
         bounds.extend(placePosition);
       }
       map.setBounds(bounds);

--- a/frontend/src/components/routeDetailPage/imageMap/imageMap.jsx
+++ b/frontend/src/components/routeDetailPage/imageMap/imageMap.jsx
@@ -5,16 +5,13 @@ const { kakao } = window;
 const ImageMap = ({ places, centerX, centerY }) => {
   const [staticMap, setStaticMap] = useState();
   const [markers, setMarkers] = useState([]);
-
+  console.log(places, centerX, centerY);
   useEffect(() => {
     function initMap() {
       // 초기 지도 생성 시 어느 지역의 지도를 보여줄 것인가?
       let staticMapContainer = document.getElementById("staticMap"),
         staticMapOption = {
-          center: new kakao.maps.LatLng(
-            centerY || 37.566826,
-            centerX || 126.9786567
-          ),
+          center: new kakao.maps.LatLng(centerY || 37.566826, centerX || 126.9786567),
           level: 4,
         };
       let map = new kakao.maps.Map(staticMapContainer, staticMapOption);
@@ -29,19 +26,14 @@ const ImageMap = ({ places, centerX, centerY }) => {
       staticMap.setCenter(new kakao.maps.LatLng(centerY, centerX));
     }
     function addMarker(position, index, map) {
-      var imageSrc =
-          "https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/marker_number_blue.png", // 마커 이미지 url, 스프라이트 이미지를 씁니다
+      var imageSrc = "https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/marker_number_blue.png", // 마커 이미지 url, 스프라이트 이미지를 씁니다
         imageSize = new kakao.maps.Size(36, 37), // 마커 이미지의 크기
         imgOptions = {
           spriteSize: new kakao.maps.Size(36, 691), // 스프라이트 이미지의 크기
           spriteOrigin: new kakao.maps.Point(0, index * 46 + 10), // 스프라이트 이미지 중 사용할 영역의 좌상단 좌표
           offset: new kakao.maps.Point(13, 37), // 마커 좌표에 일치시킬 이미지 내에서의 좌표
         },
-        markerImage = new kakao.maps.MarkerImage(
-          imageSrc,
-          imageSize,
-          imgOptions
-        ),
+        markerImage = new kakao.maps.MarkerImage(imageSrc, imageSize, imgOptions),
         marker = new kakao.maps.Marker({
           position: position, // 마커의 위치
           image: markerImage,
@@ -91,13 +83,14 @@ const ImageMap = ({ places, centerX, centerY }) => {
     }
 
     let path;
-    if (centerX && centerY && places) {
+    if (centerX && centerY) {
       moveLocationMap();
       displayMarker(staticMap);
       path = addPath(staticMap);
     }
     return () => removePath(path);
   }, [places, centerX, centerY]);
+
   return (
     <div className={styles.ImageMap}>
       <div id="staticMap" className={styles.map} />

--- a/frontend/src/components/routeDetailPage/imageMap/imageMap.jsx
+++ b/frontend/src/components/routeDetailPage/imageMap/imageMap.jsx
@@ -5,7 +5,6 @@ const { kakao } = window;
 const ImageMap = ({ places, centerX, centerY }) => {
   const [staticMap, setStaticMap] = useState();
   const [markers, setMarkers] = useState([]);
-  console.log(places, centerX, centerY);
   useEffect(() => {
     function initMap() {
       // 초기 지도 생성 시 어느 지역의 지도를 보여줄 것인가?
@@ -85,8 +84,8 @@ const ImageMap = ({ places, centerX, centerY }) => {
     let path;
     if (centerX && centerY) {
       moveLocationMap();
-      displayMarker(staticMap);
-      path = addPath(staticMap);
+      // displayMarker(staticMap);
+      // path = addPath(staticMap);
     }
     return () => removePath(path);
   }, [places, centerX, centerY]);

--- a/frontend/src/components/routeMakerPage/wishList/wishList.jsx
+++ b/frontend/src/components/routeMakerPage/wishList/wishList.jsx
@@ -7,23 +7,31 @@ import styles from "./wishList.module.css";
 const WishList = ({ wishList, onAddCart, onDeleteCart, cartItems }) => {
   const [itemsInWish, setItemsInWish] = useState([]);
   const [isClicked, setIsClicked] = useState(false);
+
+  const sortWishPlaces = useCallback(
+    (places) => {
+      const updated = cartItems.map((cartItem) => places.find((item) => item.id === cartItem.id));
+      places.forEach((item) => {
+        if (!updated.find((cartItem) => cartItem.id === item.id)) {
+          updated.push(item);
+        }
+      });
+      setItemsInWish(updated);
+    },
+    [cartItems]
+  );
+
   const onOpenPlaceList = useCallback(() => {
     setIsClicked(true);
-    setItemsInWish(wishList[0].places);
-  }, [wishList]);
+    sortWishPlaces(wishList[0].places);
+  }, [sortWishPlaces, wishList]);
+
   const onClosePlaceList = useCallback(() => {
     setIsClicked(false);
   }, []);
 
   useEffect(() => {
-    console.log(cartItems, itemsInWish);
-    const updated = itemsInWish.filter((item) => cartItems.find((cartItem) => item.id === cartItem.id));
-    itemsInWish.forEach((item) => {
-      if (!updated.find((cartItem) => cartItem.id === item.id)) {
-        updated.push(item);
-      }
-    });
-    setItemsInWish(updated);
+    sortWishPlaces(itemsInWish);
   }, [cartItems]);
 
   return (

--- a/frontend/src/components/routeMakerPage/wishList/wishList.jsx
+++ b/frontend/src/components/routeMakerPage/wishList/wishList.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import WishListCard from "../wishListCard/wishListCard";
 import WishListHeader from "../wishListHeader/wishListHeader";
 import WishPlaceCard from "../wishPlaceCard/wishPlaceCard";
@@ -14,6 +14,17 @@ const WishList = ({ wishList, onAddCart, onDeleteCart, cartItems }) => {
   const onClosePlaceList = useCallback(() => {
     setIsClicked(false);
   }, []);
+
+  useEffect(() => {
+    console.log(cartItems, itemsInWish);
+    const updated = itemsInWish.filter((item) => cartItems.find((cartItem) => item.id === cartItem.id));
+    itemsInWish.forEach((item) => {
+      if (!updated.find((cartItem) => cartItem.id === item.id)) {
+        updated.push(item);
+      }
+    });
+    setItemsInWish(updated);
+  }, [cartItems]);
 
   return (
     <div className={styles.WishList}>

--- a/frontend/src/components/routeMakerPage/wishList/wishList.jsx
+++ b/frontend/src/components/routeMakerPage/wishList/wishList.jsx
@@ -4,31 +4,33 @@ import WishListHeader from "../wishListHeader/wishListHeader";
 import WishPlaceCard from "../wishPlaceCard/wishPlaceCard";
 import styles from "./wishList.module.css";
 
-const WishList = (props) => {
-  const test = [1, 2, 3, 4, 5, 65, 7, 1];
+const WishList = ({ wishList, onAddCart }) => {
+  const [itemsInWish, setItemsInWish] = useState([]);
   const [isClicked, setIsClicked] = useState(false);
   const onOpenPlaceList = useCallback(() => {
     setIsClicked(true);
-  }, []);
+    setItemsInWish(wishList[0].places);
+  }, [wishList]);
   const onClosePlaceList = useCallback(() => {
     setIsClicked(false);
   }, []);
+
   return (
     <div className={styles.WishList}>
       <WishListHeader isClicked={isClicked} onClose={onClosePlaceList} />
       {isClicked ? (
         <ul className={styles.listContainer}>
-          {test.map((item, index) => (
+          {itemsInWish.map((item, index) => (
             <li key={index} className={styles.cardContainer} data-link={item}>
-              <WishPlaceCard />
+              <WishPlaceCard item={item} onAddCart={onAddCart} />
             </li>
           ))}
         </ul>
       ) : (
         <ul className={styles.listContainer} onClick={onOpenPlaceList}>
-          {test.map((item, index) => (
+          {wishList.map((item, index) => (
             <li key={index} className={styles.cardContainer} data-link={item}>
-              <WishListCard />
+              <WishListCard item={item} />
             </li>
           ))}
         </ul>

--- a/frontend/src/components/routeMakerPage/wishList/wishList.jsx
+++ b/frontend/src/components/routeMakerPage/wishList/wishList.jsx
@@ -32,6 +32,7 @@ const WishList = ({ wishList, onAddCart, onDeleteCart, cartItems }) => {
 
   useEffect(() => {
     sortWishPlaces(itemsInWish);
+    console.log(itemsInWish);
   }, [cartItems]);
 
   return (

--- a/frontend/src/components/routeMakerPage/wishList/wishList.jsx
+++ b/frontend/src/components/routeMakerPage/wishList/wishList.jsx
@@ -4,7 +4,7 @@ import WishListHeader from "../wishListHeader/wishListHeader";
 import WishPlaceCard from "../wishPlaceCard/wishPlaceCard";
 import styles from "./wishList.module.css";
 
-const WishList = ({ wishList, onAddCart }) => {
+const WishList = ({ wishList, onAddCart, cartItems }) => {
   const [itemsInWish, setItemsInWish] = useState([]);
   const [isClicked, setIsClicked] = useState(false);
   const onOpenPlaceList = useCallback(() => {
@@ -22,7 +22,11 @@ const WishList = ({ wishList, onAddCart }) => {
         <ul className={styles.listContainer}>
           {itemsInWish.map((item, index) => (
             <li key={index} className={styles.cardContainer} data-link={item}>
-              <WishPlaceCard item={item} onAddCart={onAddCart} />
+              <WishPlaceCard
+                item={item}
+                onAddCart={onAddCart}
+                index={cartItems.findIndex((cartItem) => cartItem.id === item.id) + 1}
+              />
             </li>
           ))}
         </ul>

--- a/frontend/src/components/routeMakerPage/wishList/wishList.jsx
+++ b/frontend/src/components/routeMakerPage/wishList/wishList.jsx
@@ -4,7 +4,7 @@ import WishListHeader from "../wishListHeader/wishListHeader";
 import WishPlaceCard from "../wishPlaceCard/wishPlaceCard";
 import styles from "./wishList.module.css";
 
-const WishList = ({ wishList, onAddCart, cartItems }) => {
+const WishList = ({ wishList, onAddCart, onDeleteCart, cartItems }) => {
   const [itemsInWish, setItemsInWish] = useState([]);
   const [isClicked, setIsClicked] = useState(false);
   const onOpenPlaceList = useCallback(() => {
@@ -25,6 +25,7 @@ const WishList = ({ wishList, onAddCart, cartItems }) => {
               <WishPlaceCard
                 item={item}
                 onAddCart={onAddCart}
+                onDeleteCart={onDeleteCart}
                 index={cartItems.findIndex((cartItem) => cartItem.id === item.id) + 1}
               />
             </li>

--- a/frontend/src/components/routeMakerPage/wishListCard/wishListCard.jsx
+++ b/frontend/src/components/routeMakerPage/wishListCard/wishListCard.jsx
@@ -1,14 +1,14 @@
 import React from "react";
 import styles from "./wishListCard.module.css";
 
-const WishListCard = (props) => {
+const WishListCard = ({ item }) => {
   const src =
     "https://i.pinimg.com/564x/d7/ec/75/d7ec75c9e68873ee75b734ac4ab09ced.jpg";
   return (
     <div className={styles.WishListCard}>
       <img className={styles.image} src={src} />
       <div className={styles.nameBox}>
-        <span className={styles.name}>뭐시기~</span>
+        <span className={styles.name}>{item.name}</span>
       </div>
     </div>
   );

--- a/frontend/src/components/routeMakerPage/wishPlaceCard/wishPlaceCard.jsx
+++ b/frontend/src/components/routeMakerPage/wishPlaceCard/wishPlaceCard.jsx
@@ -1,10 +1,8 @@
 import React, { useCallback } from "react";
 import styles from "./wishPlaceCard.module.css";
 
-const WishPlaceCard = ({ item, onAddCart }) => {
-  const index = 1;
-  const src =
-    "https://i.pinimg.com/474x/30/5a/21/305a216481dfaaec10fd59cf1f667652.jpg";
+const WishPlaceCard = ({ item, onAddCart, index }) => {
+  // const index = 1;
 
   const onAddCartFromCard = useCallback(() => {
     onAddCart(item);
@@ -12,13 +10,15 @@ const WishPlaceCard = ({ item, onAddCart }) => {
 
   return (
     <div className={styles.WishPlaceCard} onClick={onAddCartFromCard}>
-      <img className={styles.image} src={src} />
+      <img className={styles.image} src={item.image} />
       <div className={styles.nameBox}>
         <span className={styles.name}>{item.name}</span>
       </div>
-      <div className={styles.indexBox}>
-        <span className={styles.index}>{index}</span>
-      </div>
+      {index && (
+        <div className={styles.indexBox}>
+          <span className={styles.index}>{index}</span>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/routeMakerPage/wishPlaceCard/wishPlaceCard.jsx
+++ b/frontend/src/components/routeMakerPage/wishPlaceCard/wishPlaceCard.jsx
@@ -2,8 +2,6 @@ import React, { useCallback } from "react";
 import styles from "./wishPlaceCard.module.css";
 
 const WishPlaceCard = ({ item, onAddCart, index }) => {
-  // const index = 1;
-
   const onAddCartFromCard = useCallback(() => {
     onAddCart(item);
   }, [item, onAddCart]);

--- a/frontend/src/components/routeMakerPage/wishPlaceCard/wishPlaceCard.jsx
+++ b/frontend/src/components/routeMakerPage/wishPlaceCard/wishPlaceCard.jsx
@@ -1,18 +1,24 @@
 import React, { useCallback } from "react";
 import styles from "./wishPlaceCard.module.css";
 
-const WishPlaceCard = ({ item, onAddCart, index }) => {
+const WishPlaceCard = ({ item, onAddCart, onDeleteCart, index }) => {
   const onAddCartFromCard = useCallback(() => {
     onAddCart(item);
   }, [item, onAddCart]);
-
+  const onDeleteCartFromCard = useCallback(() => {
+    onDeleteCart(item.id);
+  }, [item, onDeleteCart]);
   return (
     <div className={styles.WishPlaceCard} onClick={onAddCartFromCard}>
-      <img className={styles.image} src={item.image} />
+      {item.image ? (
+        <img className={styles.image} src={item.image} alt="place img" />
+      ) : (
+        <div className={styles.imageAlt} />
+      )}
       <div className={styles.nameBox}>
         <span className={styles.name}>{item.name}</span>
       </div>
-      {index && (
+      {index !== 0 && (
         <div className={styles.indexBox}>
           <span className={styles.index}>{index}</span>
         </div>

--- a/frontend/src/components/routeMakerPage/wishPlaceCard/wishPlaceCard.jsx
+++ b/frontend/src/components/routeMakerPage/wishPlaceCard/wishPlaceCard.jsx
@@ -9,7 +9,7 @@ const WishPlaceCard = ({ item, onAddCart, onDeleteCart, index }) => {
     onDeleteCart(item.id);
   }, [item, onDeleteCart]);
   return (
-    <div className={styles.WishPlaceCard} onClick={onAddCartFromCard}>
+    <div className={styles.WishPlaceCard} onClick={index ? onDeleteCartFromCard : onAddCartFromCard}>
       {item.image ? (
         <img className={styles.image} src={item.image} alt="place img" />
       ) : (

--- a/frontend/src/components/routeMakerPage/wishPlaceCard/wishPlaceCard.jsx
+++ b/frontend/src/components/routeMakerPage/wishPlaceCard/wishPlaceCard.jsx
@@ -1,15 +1,20 @@
-import React from "react";
+import React, { useCallback } from "react";
 import styles from "./wishPlaceCard.module.css";
 
-const WishPlaceCard = () => {
+const WishPlaceCard = ({ item, onAddCart }) => {
   const index = 1;
   const src =
     "https://i.pinimg.com/474x/30/5a/21/305a216481dfaaec10fd59cf1f667652.jpg";
+
+  const onAddCartFromCard = useCallback(() => {
+    onAddCart(item);
+  }, [item, onAddCart]);
+
   return (
-    <div className={styles.WishPlaceCard}>
+    <div className={styles.WishPlaceCard} onClick={onAddCartFromCard}>
       <img className={styles.image} src={src} />
       <div className={styles.nameBox}>
-        <span className={styles.name}>place Card~</span>
+        <span className={styles.name}>{item.name}</span>
       </div>
       <div className={styles.indexBox}>
         <span className={styles.index}>{index}</span>

--- a/frontend/src/components/routeMakerPage/wishPlaceCard/wishPlaceCard.module.css
+++ b/frontend/src/components/routeMakerPage/wishPlaceCard/wishPlaceCard.module.css
@@ -3,6 +3,7 @@
   width: 100%;
   height: 100%;
 }
+.imageAlt,
 .image {
   width: 100%;
   height: 100%;
@@ -10,6 +11,9 @@
   vertical-align: middle;
   opacity: 0.8;
   border-radius: 6px;
+}
+.imageAlt {
+  background-color: hotpink;
 }
 .nameBox {
   display: flex;

--- a/frontend/src/pages/kakaoMapPage/kakaoMapPage.jsx
+++ b/frontend/src/pages/kakaoMapPage/kakaoMapPage.jsx
@@ -14,12 +14,7 @@ import "slick-carousel/slick/slick-theme.css";
 import { useRecoilValue, useSetRecoilState } from "recoil";
 import { userState, userCart } from "../../recoil/userState";
 import PortalAuth from "../../containers/portalAuth/portalAuth";
-import {
-  onAddCart,
-  onDeleteCartItem,
-  onDeleteCartAll,
-  onReceiveCart,
-} from "../../api/cartAPI";
+import { onAddCart, onDeleteCart, onDeleteCartAll, onReceiveCart } from "../../api/cartAPI";
 import SideProfileToggle from "../../components/common/sideProfileToggle/sideProfileToggle";
 import PortalPlaceList from "../../components/portal/portalPlaceList/portalPlaceList";
 import PlaceSlider from "../../components/common/placeSlider/placeSlider";
@@ -61,7 +56,7 @@ const KakaoMapPage = () => {
         const updated = prev.filter((item) => item.id !== id);
         return updated;
       });
-      onDeleteCartItem(id);
+      onDeleteCart(id);
     },
     [setShoppingItems]
   );
@@ -184,10 +179,7 @@ const KakaoMapPage = () => {
             value={inputKeyword || ""}
           />
           <div className={styles.toggle}>
-            <ShoppingCartOutlined
-              className={styles.cartIcon}
-              onClick={setCartVisibleTrue}
-            />
+            <ShoppingCartOutlined className={styles.cartIcon} onClick={setCartVisibleTrue} />
           </div>
         </form>
         <div className={styles.profileToggle}>
@@ -208,10 +200,7 @@ const KakaoMapPage = () => {
       </div>
       <div ref={placeListRef} className={styles.carouselContainer}>
         <div className={styles.mapButtonBox}>
-          <button
-            className={styles.listPortalButton}
-            onClick={onOpenListPortal}
-          >
+          <button className={styles.listPortalButton} onClick={onOpenListPortal}>
             <FontAwesomeIcon icon={faList} color="white" size="lg" />
           </button>
         </div>
@@ -256,9 +245,7 @@ const KakaoMapPage = () => {
         </Drawer>
       )}
       {needLogin && <PortalAuth onClose={portalAuthClose} />}
-      {openListPortal && (
-        <PortalPlaceList onClose={onCloseListPortal} places={searchPlaces} />
-      )}
+      {openListPortal && <PortalPlaceList onClose={onCloseListPortal} places={searchPlaces} />}
     </div>
   );
 };

--- a/frontend/src/pages/routeMakerPage/routeMakerPage.jsx
+++ b/frontend/src/pages/routeMakerPage/routeMakerPage.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { getRouteDetail } from "../../api/routeAPI";
-import { onAddCart, onReceiveCart } from "../../api/cartAPI";
+import { onAddCart, onDeleteCart, onReceiveCart } from "../../api/cartAPI";
 import CartIcon from "../../components/common/cartIcon/cartIcon";
 import Header from "../../components/common/header/header";
 import Navbar from "../../components/common/navbar/navbar";
@@ -27,7 +27,7 @@ const RouteMakerPage = (props) => {
   );
   const onDeleteCartItem = useCallback(
     async (placeId) => {
-      await onDeleteCartItem(placeId);
+      await onDeleteCart(placeId);
       getCartList();
     },
     [getCartList]
@@ -40,10 +40,6 @@ const RouteMakerPage = (props) => {
       setWishList([route]);
     }
 
-    // async function getCartList() {
-    //   const items = await onReceiveCart();
-    //   setCartItems(items);
-    // }
     getCartList();
     getRouteDetailInfo();
   }, [getCartList]);
@@ -55,11 +51,7 @@ const RouteMakerPage = (props) => {
         <CartIcon items={cartItems} onUpdateItems={getCartList} />
       </div>
       <div className={styles.mapContainer}>
-        <ImageMap
-          // places={cartItems}
-          centerX={routeDetail.centerX}
-          centerY={routeDetail.centerY}
-        />
+        <ImageMap places={cartItems} centerX={routeDetail.centerX} centerY={routeDetail.centerY} />
       </div>
       <div className={styles.wishListContainer}>
         <WishList wishList={wishList} onAddCart={onAddCartItem} onDeleteCart={onDeleteCartItem} cartItems={cartItems} />

--- a/frontend/src/pages/routeMakerPage/routeMakerPage.jsx
+++ b/frontend/src/pages/routeMakerPage/routeMakerPage.jsx
@@ -1,5 +1,7 @@
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { getRouteDetail } from "../../api/routeAPI";
+import { onAddCart, onReceiveCart } from "../../api/cartAPI";
+import CartIcon from "../../components/common/cartIcon/cartIcon";
 import Header from "../../components/common/header/header";
 import Navbar from "../../components/common/navbar/navbar";
 import ImageMap from "../../components/routeDetailPage/imageMap/imageMap";
@@ -7,24 +9,54 @@ import WishList from "../../components/routeMakerPage/wishList/wishList";
 import styles from "./routeMakerPage.module.css";
 
 const RouteMakerPage = (props) => {
+  const [wishList, setWishList] = useState([]);
   const [routeDetail, setRouteDetail] = useState({});
+  const [cartItems, setCartItems] = useState([]);
+
+  const getCartList = useCallback(async () => {
+    const items = await onReceiveCart();
+    setCartItems(items);
+  }, []);
+
+  const onAddCartItem = useCallback(
+    async (place) => {
+      await onAddCart(place);
+      getCartList();
+    },
+    [getCartList]
+  );
 
   useEffect(() => {
     async function getRouteDetailInfo() {
       // 루트 상세페이지의 정보를 받아옴
       const route = await getRouteDetail(1);
       setRouteDetail(route);
+      setWishList([route]);
     }
+
+    // async function getCartList() {
+    //   const items = await onReceiveCart();
+    //   setCartItems(items);
+    // }
+    getCartList();
     getRouteDetailInfo();
-  }, []);
+  }, [getCartList]);
+
   return (
     <div className={styles.RouteMakerPage}>
       <Header />
+      <div className={styles.cartContainer}>
+        <CartIcon items={cartItems} onUpdateItems={getCartList} />
+      </div>
       <div className={styles.mapContainer}>
-        <ImageMap places={routeDetail.places} centerX={routeDetail.centerX} centerY={routeDetail.centerY} />
+        <ImageMap
+          // places={cartItems}
+          centerX={routeDetail.centerX}
+          centerY={routeDetail.centerY}
+        />
       </div>
       <div className={styles.wishListContainer}>
-        <WishList />
+        <WishList wishList={wishList} onAddCart={onAddCartItem} />
       </div>
       <Navbar />
     </div>

--- a/frontend/src/pages/routeMakerPage/routeMakerPage.jsx
+++ b/frontend/src/pages/routeMakerPage/routeMakerPage.jsx
@@ -25,6 +25,7 @@ const RouteMakerPage = (props) => {
     },
     [getCartList]
   );
+
   const onDeleteCartItem = useCallback(
     async (placeId) => {
       await onDeleteCart(placeId);
@@ -32,6 +33,7 @@ const RouteMakerPage = (props) => {
     },
     [getCartList]
   );
+
   useEffect(() => {
     async function getRouteDetailInfo() {
       // 루트 상세페이지의 정보를 받아옴

--- a/frontend/src/pages/routeMakerPage/routeMakerPage.jsx
+++ b/frontend/src/pages/routeMakerPage/routeMakerPage.jsx
@@ -25,7 +25,13 @@ const RouteMakerPage = (props) => {
     },
     [getCartList]
   );
-
+  const onDeleteCartItem = useCallback(
+    async (placeId) => {
+      await onDeleteCartItem(placeId);
+      getCartList();
+    },
+    [getCartList]
+  );
   useEffect(() => {
     async function getRouteDetailInfo() {
       // 루트 상세페이지의 정보를 받아옴
@@ -56,7 +62,7 @@ const RouteMakerPage = (props) => {
         />
       </div>
       <div className={styles.wishListContainer}>
-        <WishList wishList={wishList} onAddCart={onAddCartItem} cartItems={cartItems} />
+        <WishList wishList={wishList} onAddCart={onAddCartItem} onDeleteCart={onDeleteCartItem} cartItems={cartItems} />
       </div>
       <Navbar />
     </div>

--- a/frontend/src/pages/routeMakerPage/routeMakerPage.jsx
+++ b/frontend/src/pages/routeMakerPage/routeMakerPage.jsx
@@ -56,7 +56,7 @@ const RouteMakerPage = (props) => {
         />
       </div>
       <div className={styles.wishListContainer}>
-        <WishList wishList={wishList} onAddCart={onAddCartItem} />
+        <WishList wishList={wishList} onAddCart={onAddCartItem} cartItems={cartItems} />
       </div>
       <Navbar />
     </div>

--- a/frontend/src/pages/routeMakerPage/routeMakerPage.module.css
+++ b/frontend/src/pages/routeMakerPage/routeMakerPage.module.css
@@ -1,8 +1,9 @@
 .cartContainer {
   position: absolute;
-  top: 30%;
-  left: 50%;
+  top: 10%;
+  left: 90%;
   z-index: 1005;
+  font-size: 1.8em;
   color: blue;
 }
 .mapContainer {

--- a/frontend/src/pages/routeMakerPage/routeMakerPage.module.css
+++ b/frontend/src/pages/routeMakerPage/routeMakerPage.module.css
@@ -1,3 +1,10 @@
+.cartContainer {
+  position: absolute;
+  top: 30%;
+  left: 50%;
+  z-index: 1005;
+  color: blue;
+}
 .mapContainer {
   height: 60vh;
 }


### PR DESCRIPTION
 루트 짜기 페이지로 장바구니 옮기기
 장바구니 리팩토링 컴포넌트화
 장바구니에 포함되어있는 place의 순서에 맞춰 표시해주기

 루트 짜는 리스트에 장소 추가 시킬 때 마다 지도에 반영 -> 카트 장소 x,y 추가되면 수정
